### PR TITLE
adding cross domains funcs

### DIFF
--- a/train_discrete.py
+++ b/train_discrete.py
@@ -46,7 +46,7 @@ class Workspace(object):
         self.train_iter = 0
         self.output = 0
 
-        if self.cfg.data == 'mnist':
+        if self.cfg.data in ['mnist', 'random', 'doodles', 'usps28']:
             na = nb = 784
             self.n_output = na
         elif self.cfg.data == 'world':
@@ -78,6 +78,15 @@ class Workspace(object):
             self.geom = train_sampler.geom
         elif self.cfg.data == 'world':
             train_sampler = data.WorldPairSampler(batch_size=self.cfg.batch_size, debug=False)
+            self.geom = train_sampler.geom
+        elif self.cfg.data == 'usps28':
+            train_sampler = data.USPSPairSampler(train=True, batch_size=self.cfg.batch_size, debug=False, reshape=True)
+            self.geom = train_sampler.geom
+        elif self.cfg.data == 'doodles':
+            train_sampler = data.DoodlePairSampler(train=True, batch_size=self.cfg.batch_size, debug=False)
+            self.geom = train_sampler.geom
+        elif self.cfg.data == 'random':
+            train_sampler = data.RandomSampler(batch_size=self.cfg.batch_size, debug=False)
             self.geom = train_sampler.geom
         else:
             assert False


### PR DESCRIPTION
I've added cross_domain functions to

* train_discrete.py: adding other samplers provided in meta_ot/data.py
* data.py: 1) RandomSampler with type attribute that allows choosing between Gaussian densities and U(0,1) zeroed at 0.95 threshold (to make it sparse as digits); 2) Doodles sampler; 3) USPS sampler from .npy file (images are reshaped using PIL);  4) geom objects are now simple linspaces for all samplers (contrary to the grid with 2d coordinates that was used before for MNIST; I've checked, it doesn't affect the results)
* eval_discrete.py: adding other samplers + test_data argument to choose on which data the model should be tested; if nothing is provided then the sampler from the saved model file is used. 
